### PR TITLE
fix errors in dropping blanks

### DIFF
--- a/app/myfitnesspal/analysis.py
+++ b/app/myfitnesspal/analysis.py
@@ -19,7 +19,7 @@ def get_most_common(diary_df: pd.DataFrame, top_n=10) -> pd.Series:
     most_common = (
         diary_df.groupby("food")
         .count()["date"]
-        .drop("")
+        .drop("", errors="ignore")
         .sort_values(ascending=False)[0:top_n]
     )
     return most_common


### PR DESCRIPTION
the fix in #8 caused issues when there were no blank entries - this tells pandas to ignore errors to handle the scenario where there are no blank entries